### PR TITLE
Set mtu size on gate env so that ssh can work

### DIFF
--- a/tempest/config.py
+++ b/tempest/config.py
@@ -294,7 +294,16 @@ ComputeGroup = [
                help='Unallocated floating IP range, which will be used to '
                     'test the floating IP bulk feature for CRUD operation. '
                     'This block must not overlap an existing floating IP '
-                    'pool.')
+                    'pool.'),
+    cfg.StrOpt('env_type',
+               default='prod',
+               choices=['gate', 'prod'],
+               help="Environment type can be gate env which is virtual or "
+                    "production."),
+    cfg.StrOpt('mtu_size',
+               default=1400,
+               help="mtu size to be set when VM is launched. This value will be"
+                    "ignored if env_type is prod.")
 ]
 
 compute_features_group = cfg.OptGroup(name='compute-feature-enabled',

--- a/tempest/services/compute/json/servers_client.py
+++ b/tempest/services/compute/json/servers_client.py
@@ -16,6 +16,7 @@
 
 import json
 import time
+import base64
 
 from six.moves.urllib import parse as urllib
 from tempest_lib import exceptions as lib_exc
@@ -72,6 +73,11 @@ class ServersClient(service_client.ServiceClient):
         if CONF.compute_feature_enabled.boot_from_volume_only:
             kwargs = boot_from_vol_client.set_block_device_mapping_args(
                      image_ref, kwargs)
+        if CONF.compute.env_type == "gate" and "user_data" not in kwargs:
+            user_data = "#!/bin/sh\n"\
+                        "sudo ifconfig eth0 mtu %s" % CONF.compute.mtu_size
+            user_data_base64 = base64.b64encode(user_data).decode('utf-8')
+            kwargs['user_data'] = user_data_base64
         if 'key_name' not in kwargs and CONF.validation.run_validation and \
             CONF.compute.ssh_auth_method == 'keypair' and CONF.compute.keypair_name:
             kwargs['key_name'] = CONF.compute.keypair_name


### PR DESCRIPTION
Using cloud-init feature set mtu size in VM launched in gate environment.
On production system this is not required.